### PR TITLE
feat: Enhance Bullet Time and add customization

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const closeSettingsBtn = document.getElementById('close-settings');
     const bloodModeSelect = document.getElementById('blood-mode');
     const goreLevelSelect = document.getElementById('gore-level');
+    const bulletTimeSpeedInput = document.getElementById('bullet-time-speed');
+    const bulletTimeValueDisplay = document.getElementById('bullet-time-value');
     const abilityPanel = document.getElementById('ability-panel');
     const abilityPanelCharName = document.getElementById('ability-panel-char-name');
     const abilityPanelAbilities = document.getElementById('ability-panel-abilities');
@@ -32,6 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Game Settings
     let bloodMode = 'on';
     let goreLevel = 'medium';
+    let bulletTimeFactor = 0.25; // Default bullet time speed
 
 
     // Game State
@@ -245,17 +248,21 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         abilityPanel.style.display = 'block';
+        gameSpeed = bulletTimeFactor; // Slow down time when ability panel is open
     }
 
     abilityPanelClose.addEventListener('click', () => {
         abilityPanel.style.display = 'none';
+        if (!targetingState) { // Only resume speed if not also targeting
+            gameSpeed = 1.0;
+        }
     });
 
     function enterTargetingMode(source, ability) {
         if (targetingState) {
             exitTargetingMode(); // Clear any previous targeting state
         }
-        gameSpeed = 0.25; // Enter bullet time
+        gameSpeed = bulletTimeFactor; // Enter bullet time
 
         logMessage(`Select a target for ${source.name}'s ${ability.name}.`, 'yellow');
         document.body.classList.add('targeting-active');
@@ -341,7 +348,10 @@ document.addEventListener('DOMContentLoaded', () => {
     function exitTargetingMode() {
         if (!targetingState) return;
 
-        gameSpeed = 1.0; // Resume normal speed
+        // Only resume speed if the ability panel isn't also open
+        if (abilityPanel.style.display !== 'block') {
+            gameSpeed = 1.0; // Resume normal speed
+        }
         clearTimeout(targetingState.timeoutId);
         document.body.classList.remove('targeting-active');
         targetingState = null;
@@ -1221,6 +1231,17 @@ document.addEventListener('DOMContentLoaded', () => {
         goreLevel = e.target.value;
     });
 
+    bulletTimeSpeedInput.addEventListener('input', (e) => {
+        const speedValue = e.target.value;
+        bulletTimeFactor = speedValue / 100;
+        bulletTimeValueDisplay.textContent = `${speedValue}%`;
+
+        // If in a state where bullet time is active, update it instantly
+        if (targetingState || abilityPanel.style.display === 'block') {
+            gameSpeed = bulletTimeFactor;
+        }
+    });
+
     playAgainBtn.addEventListener('click', () => {
         // This also needs to be async or handle data loading appropriately
         // For now, let's just restart with the already loaded data.
@@ -1257,6 +1278,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             abilityPanel.style.display = 'none';
+            if (!targetingState) { // Only resume speed if not also targeting
+                gameSpeed = 1.0;
+            }
         }
 
         // Close settings modal if click is outside of it

--- a/index.html
+++ b/index.html
@@ -76,6 +76,11 @@
                     <option value="extreme">Extreme</option>
                 </select>
             </div>
+            <div class="setting">
+                <label for="bullet-time-speed">"Bullet Time" Speed</label>
+                <input type="range" id="bullet-time-speed" min="10" max="100" value="25">
+                <span id="bullet-time-value">25%</span>
+            </div>
             <button id="close-settings">Close</button>
         </div>
     </div>

--- a/server.log
+++ b/server.log
@@ -1,0 +1,15 @@
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /style.css HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /app.js HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/heroes/squire.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/enemies/gobgob.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/equipment/rusty_longsword.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/heroes/priest.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/heroes/archer.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/enemies/gobgob_wizard.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/equipment/rusty_crossbow.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/abilities/heal.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/equipment/rusty_club.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/abilities/snipe.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /data/abilities/defend.json HTTP/1.1" 200 -
+127.0.0.1 - - [25/Aug/2025 02:43:16] "GET /Backgrounds/heavy_forest.txt HTTP/1.1" 200 -

--- a/style.css
+++ b/style.css
@@ -206,10 +206,17 @@ body.targeting-active .grid-cell.valid-target {
     margin-right: 1rem;
 }
 
-.setting select {
+.setting select, .setting input[type="range"] {
     font-family: inherit;
     font-size: 1rem;
     padding: 0.25rem;
+    vertical-align: middle;
+}
+
+.setting span {
+    display: inline-block;
+    width: 40px;
+    text-align: right;
 }
 
 #play-again-btn {


### PR DESCRIPTION
This commit introduces two main improvements to the "Bullet Time" feature:

1.  The Bullet Time effect now activates when the player opens the character ability modal. This allows players to review ability details and cooldowns at a slower game speed, providing a tactical pause.

2.  A "Bullet Time" Speed slider has been added to the settings menu. This allows users to customize the slowdown effect from 10% to 100% of the normal game speed, with a default of 25%. This provides flexibility for players who prefer a different level of slowdown or want to disable it entirely for a more challenging experience.